### PR TITLE
Fix navigation and preserve evaluator data on clear

### DIFF
--- a/client/hooks/use-demo-mode.ts
+++ b/client/hooks/use-demo-mode.ts
@@ -2,14 +2,10 @@ import { useAuth } from "@/hooks/use-auth";
 
 /**
  * Returns true only for the designated sample/demo account.
- * Access is granted when the known demo credentials are used, which sets
- * localStorage.sampleAccess = "1" during login.
+ * Strictly checks the authenticated email to avoid stale flags.
  */
 export const useDemoMode = (): boolean => {
   const { user } = useAuth();
   const email = user?.email?.toLowerCase() || "";
-  const sampleFlag =
-    typeof window !== "undefined" &&
-    localStorage.getItem("sampleAccess") === "1";
-  return email === "workerfacts@gmail.com" && sampleFlag;
+  return email === "workerfacts@gmail.com";
 };

--- a/client/pages/DownloadReport.tsx
+++ b/client/pages/DownloadReport.tsx
@@ -282,8 +282,15 @@ export default function DownloadReport() {
   };
 
   const clearAllData = () => {
-    // Clear all localStorage data including profile
+    // Clear all evaluation data but KEEP evaluator profile info
+    const evaluatorBackup = localStorage.getItem("evaluatorData");
+    const selectedProfileIdBackup = localStorage.getItem("selectedEvaluatorProfileId");
+
     localStorage.clear();
+
+    if (evaluatorBackup) localStorage.setItem("evaluatorData", evaluatorBackup);
+    if (selectedProfileIdBackup)
+      localStorage.setItem("selectedEvaluatorProfileId", selectedProfileIdBackup);
   };
 
   const generateReportContent = async () => {
@@ -6004,12 +6011,14 @@ export default function DownloadReport() {
                   including:
                 </p>
                 <ul className="text-sm text-gray-600 text-left space-y-1">
-                  <li>- Evaluator profile information</li>
                   <li>• Claimant data</li>
                   <li>• Test results and measurements</li>
                   <li>• Uploaded images</li>
                   <li>• Payment information</li>
                 </ul>
+                <p className="text-green-700 font-medium mt-2">
+                  Note: Your evaluator profile is preserved.
+                </p>
                 <p className="text-red-600 font-medium">
                   This action cannot be undone!
                 </p>

--- a/client/pages/DownloadReport.tsx
+++ b/client/pages/DownloadReport.tsx
@@ -285,12 +285,15 @@ export default function DownloadReport() {
     // Clear all evaluation data but KEEP evaluator profile info
     const evaluatorBackup = localStorage.getItem("evaluatorData");
     const selectedProfileIdBackup = localStorage.getItem("selectedEvaluatorProfileId");
+    const sampleAccessBackup = localStorage.getItem("sampleAccess");
 
     localStorage.clear();
 
     if (evaluatorBackup) localStorage.setItem("evaluatorData", evaluatorBackup);
     if (selectedProfileIdBackup)
       localStorage.setItem("selectedEvaluatorProfileId", selectedProfileIdBackup);
+    if (sampleAccessBackup)
+      localStorage.setItem("sampleAccess", sampleAccessBackup);
   };
 
   const generateReportContent = async () => {

--- a/client/pages/DownloadReport.tsx
+++ b/client/pages/DownloadReport.tsx
@@ -1656,7 +1656,7 @@ export default function DownloadReport() {
                                       symbolText = "x";
                                       symbolColor = "#ea580c";
                                     } else if (marker.type === "pins-needles") {
-                                      symbolText = "•";
+                                      symbolText = "��";
                                       symbolColor = "#7c3aed";
                                     } else if (marker.type === "numbness") {
                                       symbolText = "o";
@@ -5769,7 +5769,7 @@ export default function DownloadReport() {
   const confirmManualClear = () => {
     clearAllData();
     setShowClearDialog(false);
-    navigate("/");
+    navigate("/dashboard");
   };
 
   return (

--- a/client/pages/DownloadReport.tsx
+++ b/client/pages/DownloadReport.tsx
@@ -284,14 +284,19 @@ export default function DownloadReport() {
   const clearAllData = () => {
     // Clear all evaluation data but KEEP evaluator profile info
     const evaluatorBackup = localStorage.getItem("evaluatorData");
-    const selectedProfileIdBackup = localStorage.getItem("selectedEvaluatorProfileId");
+    const selectedProfileIdBackup = localStorage.getItem(
+      "selectedEvaluatorProfileId",
+    );
     const sampleAccessBackup = localStorage.getItem("sampleAccess");
 
     localStorage.clear();
 
     if (evaluatorBackup) localStorage.setItem("evaluatorData", evaluatorBackup);
     if (selectedProfileIdBackup)
-      localStorage.setItem("selectedEvaluatorProfileId", selectedProfileIdBackup);
+      localStorage.setItem(
+        "selectedEvaluatorProfileId",
+        selectedProfileIdBackup,
+      );
     if (sampleAccessBackup)
       localStorage.setItem("sampleAccess", sampleAccessBackup);
   };

--- a/client/pages/ProtocolTests.tsx
+++ b/client/pages/ProtocolTests.tsx
@@ -220,7 +220,6 @@ const testGroups = {
       tests: [
         { id: "cervical-flexion-extension", name: "Flexion/Extension" },
         { id: "cervical-lateral-flexion", name: "Lateral Flexion" },
-        { id: "cervical-anterior-obliques", name: "Anterior Obliques" },
         { id: "cervical-30-rotation", name: "30° Rotation" },
         { id: "cervical-60-rotation", name: "60° Rotation" },
       ],
@@ -613,6 +612,7 @@ export default function ProtocolTests() {
       // Clean up any old mcafi test IDs (replace with mcaft)
       const cleanedSelectedTests = savedData.selectedTests
         .filter((testId: string) => !testId.includes("mcafi")) // Remove old mcafi tests
+        .filter((testId: string) => testId !== "cervical-anterior-obliques")
         .map((testId: string) => {
           // This shouldn't be needed since we're filtering above, but just in case
           return testId.replace("mcafi", "mcaft");

--- a/firebase/functions/routes/createCheckoutSession.js
+++ b/firebase/functions/routes/createCheckoutSession.js
@@ -47,9 +47,6 @@
 
 // module.exports = router;
 
-
-
-
 const express = require("express");
 const Stripe = require("stripe");
 

--- a/shared/references.ts
+++ b/shared/references.ts
@@ -337,7 +337,6 @@ export const getReferencesForTest = (testId: string): Reference[] => {
     // Range of Motion Tests (Cervical, Lumbar, etc.)
     "cervical-flexion-extension": "range-of-motion",
     "cervical-lateral-flexion": "range-of-motion",
-    "cervical-anterior-obliques": "range-of-motion",
     "cervical-30-rotation": "range-of-motion",
     "cervical-60-rotation": "range-of-motion",
     "cervical-spine-flexion-extension": "range-of-motion",


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several issues with the clear data functionality:
- Users were being navigated to homepage instead of dashboard after clearing data
- Evaluator profile information was being lost when clearing data, causing the sample fill button to disappear for workerfacts@gmail.com
- Need to ensure sample fill button consistently shows for the designated demo account

## Code changes

**Navigation Fix:**
- Updated clear data flow to navigate to `/dashboard` instead of `/` (homepage)

**Data Preservation:**
- Modified `clearAllData()` function to preserve evaluator profile information, selected profile ID, and sample access flags
- Updated clear confirmation dialog to clarify that evaluator profile is preserved

**Demo Mode Logic:**
- Simplified `useDemoMode` hook to rely solely on authenticated email check for workerfacts@gmail.com
- Removed dependency on localStorage sampleAccess flag to prevent stale state issues

**Test Cleanup:**
- Removed deprecated "cervical-anterior-obliques" test from protocol tests and references
- Added filtering to remove this test from existing saved data

**UI Updates:**
- Updated clear dialog messaging to reflect that evaluator profile is preserved
- Fixed symbol rendering for pins-needles markers in report generationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 42`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6ef0897028464d5a82d11c352f117948/zen-landing)

👀 [Preview Link](https://6ef0897028464d5a82d11c352f117948-zen-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6ef0897028464d5a82d11c352f117948</projectId>-->
<!--<branchName>zen-landing</branchName>-->